### PR TITLE
Add Google Analytics script registry

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,7 +16,14 @@ export default defineNuxtConfig({
       PAYSTACK_PUBLIC_KEY: process.env.PAYSTACK_PUBLIC_KEY,
     },
   },
-
+  script:{
+    registry:{
+      googleAnalytics: {
+        id: process.env.GOOGLE_ANALYTICS_ID,
+        trigger: 'onNuxtReady'
+      }
+    }
+  },
   modules: [
     [
       "@nuxtjs/supabase",


### PR DESCRIPTION
Add a script.registry.googleAnalytics entry to nuxt.config.ts to register Google Analytics via the environment variable GOOGLE_ANALYTICS_ID and trigger it onNuxtReady. This integrates GA as a Nuxt-managed script and avoids hardcoding the tracking ID.