### PR TITLE
Add nuxt-gtag and gtag config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,14 +16,6 @@ export default defineNuxtConfig({
       PAYSTACK_PUBLIC_KEY: process.env.PAYSTACK_PUBLIC_KEY,
     },
   },
-  script:{
-    registry:{
-      googleAnalytics: {
-        id: process.env.GOOGLE_ANALYTICS_ID,
-        trigger: 'onNuxtReady'
-      }
-    }
-  },
   modules: [
     [
       "@nuxtjs/supabase",
@@ -34,7 +26,8 @@ export default defineNuxtConfig({
       },
     ],
     "@nuxt/fonts",
-    'nuxt-mail'
+    'nuxt-mail',
+    'nuxt-gtag'
   ],
 
   // nuxt-mail SMTP configuration
@@ -50,6 +43,9 @@ export default defineNuxtConfig({
         pass: process.env.GOOGLE_PASSWORD,
       },
     }
+  },
+  gtag:{
+    id: process.env.GOOGLE_ANALYTICS_ID,
   },
 
   css: [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "firebase": "^12.12.1",
     "googleapis": "^146.0.0",
     "nuxt": "^3.14.1592",
+    "nuxt-gtag": "4.1.0",
     "nuxt-mail": "7.0.1",
     "oxc-parser": "^0.75.0",
     "vue": "latest",


### PR DESCRIPTION
Replace the previous script.registry Google Analytics setup with the nuxt-gtag module: remove the script.registry.googleAnalytics block from nuxt.config.ts, add 'nuxt-gtag' to modules and a gtag config that reads GOOGLE_ANALYTICS_ID from env. Add the nuxt-gtag dependency in package.json and include the generated yarn.lock. Existing nuxt-mail and other configs are left intact.