### PR TITLE
fix: re-show pre-quiz popup on every un-started indicator

### DIFF
--- a/composables/useQuizProgress.js
+++ b/composables/useQuizProgress.js
@@ -3,9 +3,6 @@ import { ref, readonly, onMounted } from 'vue';
 // Global quiz completion state
 const completedQuizzes = ref(new Set());
 const contentStatus = ref(new Map());
-// Tracks which substrands have already shown their one-time pre-quiz, keyed
-// by a caller-supplied substrand key (e.g. `${moduleSlug}-substrand-${substrandId}`).
-const seenSubstrandQuizzes = ref(new Set());
 
 // Load state from localStorage on client side
 const loadStateFromStorage = () => {
@@ -13,7 +10,6 @@ const loadStateFromStorage = () => {
     try {
       const savedCompleted = localStorage.getItem('completedQuizzes');
       const savedStatus = localStorage.getItem('contentStatus');
-      const savedSeenSubstrandQuizzes = localStorage.getItem('seenSubstrandQuizzes');
 
       if (savedCompleted) {
         completedQuizzes.value = new Set(JSON.parse(savedCompleted));
@@ -21,10 +17,6 @@ const loadStateFromStorage = () => {
 
       if (savedStatus) {
         contentStatus.value = new Map(JSON.parse(savedStatus));
-      }
-
-      if (savedSeenSubstrandQuizzes) {
-        seenSubstrandQuizzes.value = new Set(JSON.parse(savedSeenSubstrandQuizzes));
       }
     } catch (error) {
       console.error('Error loading quiz progress from localStorage:', error);
@@ -38,7 +30,6 @@ const saveStateToStorage = () => {
     try {
       localStorage.setItem('completedQuizzes', JSON.stringify(Array.from(completedQuizzes.value)));
       localStorage.setItem('contentStatus', JSON.stringify(Array.from(contentStatus.value.entries())));
-      localStorage.setItem('seenSubstrandQuizzes', JSON.stringify(Array.from(seenSubstrandQuizzes.value)));
     } catch (error) {
       console.error('Error saving quiz progress to localStorage:', error);
     }
@@ -71,18 +62,6 @@ export const useQuizProgress = () => {
     return contentStatus.value.get(contentId) || 'not-started';
   };
 
-  // Has the one-time pre-quiz already been shown for this substrand?
-  const hasSeenSubstrandQuiz = (substrandKey) => {
-    return seenSubstrandQuizzes.value.has(substrandKey);
-  };
-
-  // Mark the substrand's pre-quiz as shown so later indicator clicks in the
-  // same substrand skip straight to content instead of re-showing the quiz.
-  const markSubstrandQuizSeen = (substrandKey) => {
-    seenSubstrandQuizzes.value.add(substrandKey);
-    saveStateToStorage();
-  };
-
   const getStatusInfo = (status) => {
     switch (status) {
       case 'completed':
@@ -113,8 +92,6 @@ export const useQuizProgress = () => {
     getStatusInfo,
     getAllCompletedQuizzes,
     getCompletedCount,
-    hasSeenSubstrandQuiz,
-    markSubstrandQuizSeen,
     loadStateFromStorage,
     saveStateToStorage
   };

--- a/pages/learning-modules/assignment_workbook1/strand-[id]/substrand-[route]/index.vue
+++ b/pages/learning-modules/assignment_workbook1/strand-[id]/substrand-[route]/index.vue
@@ -15,12 +15,8 @@ const {
   isQuizCompleted,
   getContentStatus,
   getStatusInfo,
-  hasSeenSubstrandQuiz,
-  markSubstrandQuizSeen,
   loadStateFromStorage,
 } = useQuizProgress();
-
-const moduleSlug = "assignment_workbook1";
 
 const { data: substrand } = await client
   .from("book1_strand_substrands_lists")
@@ -28,9 +24,6 @@ const { data: substrand } = await client
   .eq("route", substrand_ref);
 const strand_ref_id = substrand[0].strand_ref;
 const substrand_ref_id = substrand[0].id;
-// One-time gate for the whole-substrand pre-quiz: shown on the first
-// indicator click in this substrand, skipped on every click after that.
-const substrandQuizKey = `${moduleSlug}-substrand-${substrand_ref_id}`;
 
 const { data: strands } = await client
   .from("book1_strands")
@@ -84,20 +77,17 @@ function openBece() {
 // SubstrandQuiz page (components/SubstrandQuiz.vue) on first click.
 
 const handleContentClick = (contentId) => {
-  // The pre-quiz is shown only once per substrand, on the first indicator
-  // click. Every indicator click after that (whichever indicator) goes
-  // straight to that indicator's content.
+  // First click on an indicator routes to the whole-substrand pre-quiz (10
+  // questions). Once that indicator is started/completed, clicking it opens
+  // the course content directly. Each indicator is tracked independently, so
+  // only the selected one advances; the rest stay "not started".
   const key = quizKey(contentId);
-  if (!hasSeenSubstrandQuiz(substrandQuizKey)) {
-    markSubstrandQuizSeen(substrandQuizKey);
+  if (getContentStatus(key) === "not-started") {
     markQuizInProgress(key);
     navigateTo(
       `/learning-modules/assignment_workbook1/strand-${strand_ref_id}/substrand-${substrand_ref}/quiz/${contentId}`,
     );
   } else {
-    if (getContentStatus(key) === "not-started") {
-      markQuizInProgress(key);
-    }
     navigateTo(
       `/learning-modules/assignment_workbook1/strand-${strand_ref_id}/substrand-${substrand_ref}/${contentId}`,
     );

--- a/pages/learning-modules/assignment_workbook2/strand-[id]/substrand-[route]/index.vue
+++ b/pages/learning-modules/assignment_workbook2/strand-[id]/substrand-[route]/index.vue
@@ -15,12 +15,8 @@ const {
   isQuizCompleted,
   getContentStatus,
   getStatusInfo,
-  hasSeenSubstrandQuiz,
-  markSubstrandQuizSeen,
   loadStateFromStorage,
 } = useQuizProgress();
-
-const moduleSlug = "assignment_workbook2";
 
 const { data: substrand } = await client
   .from("book1_strand_substrands_lists")
@@ -28,9 +24,6 @@ const { data: substrand } = await client
   .eq("route", substrand_ref);
 const strand_ref_id = substrand[0].strand_ref;
 const substrand_ref_id = substrand[0].id;
-// One-time gate for the whole-substrand pre-quiz: shown on the first
-// indicator click in this substrand, skipped on every click after that.
-const substrandQuizKey = `${moduleSlug}-substrand-${substrand_ref_id}`;
 
 const { data: strands } = await client
   .from("book2_strands")
@@ -89,20 +82,17 @@ function openBece() {
 // SubstrandQuiz page (components/SubstrandQuiz.vue) on first click.
 
 const handleContentClick = (contentId) => {
-  // The pre-quiz is shown only once per substrand, on the first indicator
-  // click. Every indicator click after that (whichever indicator) goes
-  // straight to that indicator's content.
+  // First click on an indicator routes to the whole-substrand pre-quiz (10
+  // questions). Once that indicator is started/completed, clicking it opens
+  // the course content directly. Each indicator is tracked independently, so
+  // only the selected one advances; the rest stay "not started".
   const key = quizKey(contentId);
-  if (!hasSeenSubstrandQuiz(substrandQuizKey)) {
-    markSubstrandQuizSeen(substrandQuizKey);
+  if (getContentStatus(key) === "not-started") {
     markQuizInProgress(key);
     navigateTo(
       `/learning-modules/assignment_workbook2/strand-${strand_ref_id}/substrand-${substrand_ref}/quiz/${contentId}`,
     );
   } else {
-    if (getContentStatus(key) === "not-started") {
-      markQuizInProgress(key);
-    }
     navigateTo(
       `/learning-modules/assignment_workbook2/strand-${strand_ref_id}/substrand-${substrand_ref}/${contentId}`,
     );

--- a/pages/learning-modules/assignment_workbook3/strand-[id]/substrand-[route]/index.vue
+++ b/pages/learning-modules/assignment_workbook3/strand-[id]/substrand-[route]/index.vue
@@ -15,12 +15,8 @@ const {
   isQuizCompleted,
   getContentStatus,
   getStatusInfo,
-  hasSeenSubstrandQuiz,
-  markSubstrandQuizSeen,
   loadStateFromStorage,
 } = useQuizProgress();
-
-const moduleSlug = "assignment_workbook3";
 
 const { data: substrand } = await client
   .from("book1_strand_substrands_lists")
@@ -28,9 +24,6 @@ const { data: substrand } = await client
   .eq("route", substrand_ref);
 const strand_ref_id = substrand[0].strand_ref;
 const substrand_ref_id = substrand[0].id;
-// One-time gate for the whole-substrand pre-quiz: shown on the first
-// indicator click in this substrand, skipped on every click after that.
-const substrandQuizKey = `${moduleSlug}-substrand-${substrand_ref_id}`;
 
 const { data: strands } = await client
   .from("book3_strands")
@@ -89,20 +82,17 @@ function openBece() {
 // SubstrandQuiz page (components/SubstrandQuiz.vue) on first click.
 
 const handleContentClick = (contentId) => {
-  // The pre-quiz is shown only once per substrand, on the first indicator
-  // click. Every indicator click after that (whichever indicator) goes
-  // straight to that indicator's content.
+  // First click on an indicator routes to the whole-substrand pre-quiz (10
+  // questions). Once that indicator is started/completed, clicking it opens
+  // the course content directly. Each indicator is tracked independently, so
+  // only the selected one advances; the rest stay "not started".
   const key = quizKey(contentId);
-  if (!hasSeenSubstrandQuiz(substrandQuizKey)) {
-    markSubstrandQuizSeen(substrandQuizKey);
+  if (getContentStatus(key) === "not-started") {
     markQuizInProgress(key);
     navigateTo(
       `/learning-modules/assignment_workbook3/strand-${strand_ref_id}/substrand-${substrand_ref}/quiz/${contentId}`,
     );
   } else {
-    if (getContentStatus(key) === "not-started") {
-      markQuizInProgress(key);
-    }
     navigateTo(
       `/learning-modules/assignment_workbook3/strand-${strand_ref_id}/substrand-${substrand_ref}/${contentId}`,
     );

--- a/pages/learning-modules/preassignment_workbook1/strand-[id]/substrand-[route]/index.vue
+++ b/pages/learning-modules/preassignment_workbook1/strand-[id]/substrand-[route]/index.vue
@@ -15,12 +15,8 @@ const {
   isQuizCompleted,
   getContentStatus,
   getStatusInfo,
-  hasSeenSubstrandQuiz,
-  markSubstrandQuizSeen,
   loadStateFromStorage,
 } = useQuizProgress();
-
-const moduleSlug = "preassignment_workbook1";
 
 const { data: substrand } = await client
   .from("preassignment_workbook1_strand_substrands_lists")
@@ -28,9 +24,6 @@ const { data: substrand } = await client
   .eq("route", substrand_ref);
 const strand_ref_id = substrand[0].strand_ref;
 const substrand_ref_id = substrand[0].id;
-// One-time gate for the whole-substrand pre-quiz: shown on the first
-// indicator click in this substrand, skipped on every click after that.
-const substrandQuizKey = `${moduleSlug}-substrand-${substrand_ref_id}`;
 
 const { data: strands } = await client
   .from("preassignment_workbook1_substrands_contents")
@@ -82,20 +75,17 @@ function openBece() {
 // SubstrandQuiz page (components/SubstrandQuiz.vue) on first click.
 
 const handleContentClick = (contentId) => {
-  // The pre-quiz is shown only once per substrand, on the first indicator
-  // click. Every indicator click after that (whichever indicator) goes
-  // straight to that indicator's content.
+  // First click on an indicator routes to the whole-substrand pre-quiz (10
+  // questions). Once that indicator is started/completed, clicking it opens
+  // the course content directly. Each indicator is tracked independently, so
+  // only the selected one advances; the rest stay "not started".
   const key = quizKey(contentId);
-  if (!hasSeenSubstrandQuiz(substrandQuizKey)) {
-    markSubstrandQuizSeen(substrandQuizKey);
+  if (getContentStatus(key) === "not-started") {
     markQuizInProgress(key);
     navigateTo(
       `/learning-modules/preassignment_workbook1/strand-${strand_ref_id}/substrand-${substrand_ref}/quiz/${contentId}`,
     );
   } else {
-    if (getContentStatus(key) === "not-started") {
-      markQuizInProgress(key);
-    }
     navigateTo(
       `/learning-modules/preassignment_workbook1/strand-${strand_ref_id}/substrand-${substrand_ref}/${contentId}`,
     );

--- a/pages/learning-modules/preassignment_workbook2/strand-[id]/substrand-[route]/index.vue
+++ b/pages/learning-modules/preassignment_workbook2/strand-[id]/substrand-[route]/index.vue
@@ -15,12 +15,8 @@ const {
   isQuizCompleted,
   getContentStatus,
   getStatusInfo,
-  hasSeenSubstrandQuiz,
-  markSubstrandQuizSeen,
   loadStateFromStorage,
 } = useQuizProgress();
-
-const moduleSlug = "preassignment_workbook2";
 
 const { data: substrand } = await client
   .from("preassignment_workbook2_strand_substrands_lists")
@@ -28,9 +24,6 @@ const { data: substrand } = await client
   .eq("route", substrand_ref);
 const strand_ref_id = substrand[0].strand_ref;
 const substrand_ref_id = substrand[0].id;
-// One-time gate for the whole-substrand pre-quiz: shown on the first
-// indicator click in this substrand, skipped on every click after that.
-const substrandQuizKey = `${moduleSlug}-substrand-${substrand_ref_id}`;
 
 const { data: strands } = await client
   .from("preassignment_workbook2_substrands_contents")
@@ -82,20 +75,17 @@ function openBece() {
 // SubstrandQuiz page (components/SubstrandQuiz.vue) on first click.
 
 const handleContentClick = (contentId) => {
-  // The pre-quiz is shown only once per substrand, on the first indicator
-  // click. Every indicator click after that (whichever indicator) goes
-  // straight to that indicator's content.
+  // First click on an indicator routes to the whole-substrand pre-quiz (10
+  // questions). Once that indicator is started/completed, clicking it opens
+  // the course content directly. Each indicator is tracked independently, so
+  // only the selected one advances; the rest stay "not started".
   const key = quizKey(contentId);
-  if (!hasSeenSubstrandQuiz(substrandQuizKey)) {
-    markSubstrandQuizSeen(substrandQuizKey);
+  if (getContentStatus(key) === "not-started") {
     markQuizInProgress(key);
     navigateTo(
       `/learning-modules/preassignment_workbook2/strand-${strand_ref_id}/substrand-${substrand_ref}/quiz/${contentId}`,
     );
   } else {
-    if (getContentStatus(key) === "not-started") {
-      markQuizInProgress(key);
-    }
     navigateTo(
       `/learning-modules/preassignment_workbook2/strand-${strand_ref_id}/substrand-${substrand_ref}/${contentId}`,
     );

--- a/pages/learning-modules/preassignment_workbook3/strand-[id]/substrand-[route]/index.vue
+++ b/pages/learning-modules/preassignment_workbook3/strand-[id]/substrand-[route]/index.vue
@@ -15,12 +15,8 @@ const {
   isQuizCompleted,
   getContentStatus,
   getStatusInfo,
-  hasSeenSubstrandQuiz,
-  markSubstrandQuizSeen,
   loadStateFromStorage,
 } = useQuizProgress();
-
-const moduleSlug = "preassignment_workbook3";
 
 const { data: substrand } = await client
   .from("preassignment_workbook3_strand_substrands_lists")
@@ -28,9 +24,6 @@ const { data: substrand } = await client
   .eq("route", substrand_ref);
 const strand_ref_id = substrand[0].strand_ref;
 const substrand_ref_id = substrand[0].id;
-// One-time gate for the whole-substrand pre-quiz: shown on the first
-// indicator click in this substrand, skipped on every click after that.
-const substrandQuizKey = `${moduleSlug}-substrand-${substrand_ref_id}`;
 
 const { data: strands } = await client
   .from("preassignment_workbook3_substrands_contents")
@@ -82,20 +75,17 @@ function openBece() {
 // SubstrandQuiz page (components/SubstrandQuiz.vue) on first click.
 
 const handleContentClick = (contentId) => {
-  // The pre-quiz is shown only once per substrand, on the first indicator
-  // click. Every indicator click after that (whichever indicator) goes
-  // straight to that indicator's content.
+  // First click on an indicator routes to the whole-substrand pre-quiz (10
+  // questions). Once that indicator is started/completed, clicking it opens
+  // the course content directly. Each indicator is tracked independently, so
+  // only the selected one advances; the rest stay "not started".
   const key = quizKey(contentId);
-  if (!hasSeenSubstrandQuiz(substrandQuizKey)) {
-    markSubstrandQuizSeen(substrandQuizKey);
+  if (getContentStatus(key) === "not-started") {
     markQuizInProgress(key);
     navigateTo(
       `/learning-modules/preassignment_workbook3/strand-${strand_ref_id}/substrand-${substrand_ref}/quiz/${contentId}`,
     );
   } else {
-    if (getContentStatus(key) === "not-started") {
-      markQuizInProgress(key);
-    }
     navigateTo(
       `/learning-modules/preassignment_workbook3/strand-${strand_ref_id}/substrand-${substrand_ref}/${contentId}`,
     );


### PR DESCRIPTION
## Summary
- Reverts the pre-quiz gating introduced in d92453f, which showed the pre-quiz popup only once per substrand (on the first indicator click), then let every subsequent indicator in that substrand skip straight to content.
- Restores per-indicator gating: clicking any indicator whose own quiz status is `not-started` shows the pre-quiz popup first; indicators already in-progress/completed still skip straight to content.
- Applied identically across all 6 learning modules (`assignment_workbook1/2/3`, `preassignment_workbook1/2/3`).
- Removes the now-unused `seenSubstrandQuizzes` localStorage tracking (`hasSeenSubstrandQuiz`/`markSubstrandQuizSeen`) from `composables/useQuizProgress.js`, since nothing references it anymore.

## Why
User confirmed the popup should reappear "when the user clicks a substrand's indicator for the first time" — i.e. per indicator, not once for the whole substrand.

## Test plan
- [x] Logged into the running dev server and walked through `assignment_workbook1 → Strand 1 → Number and Numeration System`:
  - First click on indicator 1 (not started) → routed to `/quiz/1`, popup shown.
  - Click on indicator 2 (not started, same substrand) → routed to `/quiz/2`, popup shown again (previously would have skipped straight to content).
  - Re-click on indicator 1 (now in-progress) → routed straight to `/1` (content), no popup, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)